### PR TITLE
added support for topology

### DIFF
--- a/sankey.js
+++ b/sankey.js
@@ -164,7 +164,7 @@ d3.sankey = function() {
         (position, point, index) => (point.includes(node.name))
           ? index
           : position,
-        0) || node.x
+        0) || node.x;
     });
   }
 

--- a/sankey.js
+++ b/sankey.js
@@ -5,6 +5,7 @@ d3.sankey = function() {
       size = [1, 1],
       nodes = [],
       links = [],
+      topology = [],
       sinksRight = true;
 
   sankey.nodeWidth = function(_) {
@@ -28,6 +29,12 @@ d3.sankey = function() {
   sankey.links = function(_) {
     if (!arguments.length) return links;
     links = _;
+    return sankey;
+  };
+
+  sankey.topology = function(_) {
+    if (!arguments.length) return topology;
+    topology = _;
     return sankey;
   };
 
@@ -139,12 +146,26 @@ d3.sankey = function() {
       ++x;
     }
 
+    if (topology.length > 0) {
+      checkBreadthsAgainstTopology();
+    }
+
     // Optionally move pure sinks always to the right.
     if (sinksRight) {
       moveSinksRight(x);
     }
 
     scaleNodeBreadths((size[0] - nodeWidth) / (x - 1));
+  }
+
+  function checkBreadthsAgainstTopology () {
+    nodes.forEach((node) => {
+      node.x = topology.reduce(
+        (position, point, index) => (point.includes(node.name))
+          ? index
+          : position,
+        0) || node.x
+    });
   }
 
   function moveSourcesRight() {


### PR DESCRIPTION
The plugin works fine when we assume all the paths are going to be linked to each layer, apart from the final layer. This PR includes support for a forced topology that will update each node position accordingly, if the correct position hasn't been achieved beforehand. That way the topology doesn't need to comprise all the nodes, only those that require a predetermined position.
The topology has the following data structure:
```
declare var topology: [[string]];
const topology = [
  ['A', 'B', ...restLayer1],
  ['C', ...restLayer2],
  ['D', ...restLayer3],
  ...restLayers,
  ['N', ...restLayerN],
  ...rest
];
```
Suppose you have the following data structure:
```
const nodes = [
  {name: "A"},
  {name: "B"},
  {name: "C"},
  {name: "D"},
  {name: "E"}
];
const links = {
  {source: 'A', target: 'B', value: 1},
  {source: 'A', target: 'C', value: 1},
  {source: 'B', target: 'D', value: 1},
  {source: 'D', target: 'E', value: 1},
  {source: 'C', target: 'E', value: 1},
};
const topology = [
  ['A'],
  ['B'],
  ['C', 'D'],
  ['E'],
] ;
```
The plugin will now draw the sankey graph with the node `C` along with `D`.